### PR TITLE
Update .gitignore - Add bin folder to ignore :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+bin/


### PR DESCRIPTION
A pasta "bin/" contém os arquivos bytecodes (classes) geradas durante a compilação do sistemas. Não há a necessidade de enviar essa pasta para o repositório.